### PR TITLE
Stop early if requested version is already installed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,10 @@ jobs:
         with:
           node-version: 16
 
+      # this ensures that tests do not timeout
+      - run: ghc --version
+      - run: ghcup list
+
       - run: npm ci
       - run: npm test
 

--- a/src/resolve.spec.ts
+++ b/src/resolve.spec.ts
@@ -1,4 +1,4 @@
-import { compareVersions, resolveVersion, resolve } from '../src/resolve';
+import { compareVersions, resolveVersion, resolve, installed } from '../src/resolve';
 
 const context = describe;
 
@@ -88,6 +88,24 @@ describe('resolve', () => {
     expect(await resolve('8.10.6')).toEqual({
       version: '8.10.6',
       source: 'ghcup',
+    });
+  });
+
+  it('resolves "system"', async () => {
+    const expected = await installed();
+    expect(await resolve('system')).toEqual({
+      version: expected,
+      source: 'system',
+    });
+  });
+
+  context('when version is already installed', () => {
+    it('sets "source" to "system"', async () => {
+      const expected = await installed();
+      expect(await resolve(expected)).toEqual({
+        version: expected,
+        source: 'system',
+      });
     });
   });
 


### PR DESCRIPTION
This doesn't make a differentec on macOS and Linux, but it is necessary to prevent reinstalls on Windows.